### PR TITLE
feat: add dev:local script for local development mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "scripts": {
     "build:sdk": "tsup src/index.ts --format esm,cjs --dts",
     "dev": "tsup src/index.ts --format esm,cjs --watch --dts",
+    "dev:local": "npm run dev",
     "test": "jest"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
Add `dev:local` script to package.json that delegates to the regular `dev` script.

## Why this change?
This maintains consistency with other packages in monorepos that need local development mode support. Some monorepos distinguish between hosted and local development environments, and this script provides that flexibility without changing the existing development workflow.

## Changes
- Added `"dev:local": "npm run dev"` script to package.json
- No changes to existing functionality - maintains full backward compatibility

## Test plan
- [x] Verified `npm run dev` continues to work as expected
- [x] Verified `npm run dev:local` works and delegates correctly
- [x] Confirmed no breaking changes to existing scripts

The change is minimal and maintains full backward compatibility while providing the needed flexibility for monorepo environments.