### PR TITLE
fix: return false and error message inside sponsorTx

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meshsdk/web3-sdk",
-  "version": "0.0.62",
+  "version": "0.0.63",
   "description": "UTXOS SDK - Mesh Web3 Services",
   "main": "./dist/index.cjs",
   "browser": "./dist/index.js",

--- a/src/sdk/sponsorship/index.ts
+++ b/src/sdk/sponsorship/index.ts
@@ -81,9 +81,10 @@ export class Sponsorship {
     );
 
     if (status !== 200) {
-      throw new Error(
-        "Invalid sponsorship ID or failed to fetch sponsorship config",
-      );
+      return {
+        success: false,
+        error: "Invalid sponsorship ID or failed to fetch sponsorship config",
+      };
     }
 
     const sponsorshipConfig = data as SponsorshipConfig;


### PR DESCRIPTION
API doesn't expect an error to be thrown, very likely none of users will perceive this as a breaking change, as it was behaving incorrectly to begin with.