### PR TITLE
fix(cardano): correct getWalletsByTag URL path and encode tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utxos/sdk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "UTXOS SDK - Web3 infrastructure platform for UTXO blockchains",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/sdk/wallet-developer-controlled/cardano.ts
+++ b/src/sdk/wallet-developer-controlled/cardano.ts
@@ -142,7 +142,7 @@ export class CardanoWalletDeveloperControlled {
     }
 
     const { data, status } = await this.sdk.axiosInstance.get(
-      `api/project-wallet/${this.sdk.projectId}/cardano/tag/${tag}`,
+      `api/project-wallet/${this.sdk.projectId}/tag/${encodeURIComponent(tag)}`,
     );
 
     if (status === 200) {


### PR DESCRIPTION
## Summary
- `getWalletsByTag` was calling `api/project-wallet/{projectId}/cardano/tag/{tag}`, which does not exist on the server. The actual route is `api/project-wallet/{projectId}/tag/{tagstring}` (see [`apps/app/src/pages/api/project-wallet/[projectId]/tag/[tagstring].ts`](https://github.com/utxos-dev/utxos-dev/blob/main/apps/app/src/pages/api/project-wallet/%5BprojectId%5D/tag/%5Btagstring%5D.ts)). Every call returned a 404 HTML page even when matching wallets existed.
- URL-encode the tag so emails and any tag with `@`, `/`, spaces, or other special characters round-trip safely through the path segment.
- Bumped to `0.2.3`.

## Repro (before patch)
```ts
const sdk = new Web3Sdk({ projectId, apiKey, privateKey, network: "mainnet" });
await sdk.wallet.cardano.getWalletsByTag("alice@example.com");
// AxiosError: Request failed with status code 404
// url: api/project-wallet/.../cardano/tag/alice@example.com
```

## After patch
Verified end-to-end against `https://utxos.dev` with 5 random wallet tags from a real 379-wallet project — every call returned the expected `MultiChainWalletInfo[]` with matching `id` and `tags`.

```
[1/5] mitsuo.watase@equilibrio-inc.com
  csv  id=1ed8e98b-c909-4126-bf6d-78dbff51420a
  api  id=1ed8e98b-c909-4126-bf6d-78dbff51420a ✓
  tags=["mitsuo.watase@equilibrio-inc.com"] ✓
...
[utxos] sample done. pass=5 fail=0 total=5
```

## Test plan
- [x] Manual: `sdk.wallet.cardano.getWalletsByTag(email)` returns matching wallets on mainnet
- [x] Manual: tags containing `@` work (email tags)
- [ ] Add a unit/integration test that asserts the URL path the SDK hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)