### PR TITLE
disable apple for non-custodian wallet auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Visit [UTXOS](https://utxos.dev/) for more information.
 
 - **Multi-Chain Support**: Bitcoin, Cardano, and Spark blockchains
 - **Developer-Controlled Wallets**: Manage wallets on behalf of users with secure backend integration
-- **User-Controlled Wallets**: Non-custodial wallet solutions with OAuth integration (Google, Twitter, Discord, Apple)
+- **User-Controlled Wallets**: Non-custodial wallet solutions with OAuth integration (Google, Twitter, Discord)
 - **Transaction Sponsorship**: Sponsor transactions for gasless user experiences
 - **Shard-Based Security**: Client-side key management with multi-shard encryption
 - **TypeScript Native**: Full type safety and IntelliSense support

--- a/examples/nextjs/app/layout.tsx
+++ b/examples/nextjs/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "UTXOS Wallet | Web3 Wallet as a Service",
-  description: "Connect your wallet with social login - Google, Discord, Twitter, Apple, Email",
+  description: "Connect your wallet with social login — Google, Discord, Twitter, Email",
 };
 
 export default function RootLayout({

--- a/examples/nextjs/app/page.tsx
+++ b/examples/nextjs/app/page.tsx
@@ -21,7 +21,6 @@ const PROVIDERS: { id: Web3AuthProvider; label: string; icon: string }[] = [
   { id: "google", label: "Google", icon: "G" },
   { id: "discord", label: "Discord", icon: "D" },
   { id: "twitter", label: "Twitter", icon: "X" },
-  { id: "apple", label: "Apple", icon: "" },
   { id: "email", label: "Email", icon: "@" },
 ];
 

--- a/examples/react-native/App.tsx
+++ b/examples/react-native/App.tsx
@@ -32,7 +32,6 @@ const PROVIDERS: { id: Web3AuthProvider; label: string; icon: string }[] = [
   { id: "google", label: "Google", icon: "G" },
   { id: "discord", label: "Discord", icon: "D" },
   { id: "twitter", label: "Twitter", icon: "X" },
-  { id: "apple", label: "Apple", icon: "" },
   { id: "email", label: "Email", icon: "@" },
 ];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utxos/sdk",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "UTXOS SDK - Web3 infrastructure platform for UTXO blockchains",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/non-custodial/index.ts
+++ b/src/non-custodial/index.ts
@@ -104,7 +104,11 @@ export type Web3NonCustodialProviderParams = {
   googleOauth2ClientId: string;
   twitterOauth2ClientId: string;
   discordOauth2ClientId: string;
-  appleOauth2ClientId: string;
+  /**
+   * @deprecated Apple Sign In was removed. Omit this field. If a non-empty value is passed,
+   * the constructor throws so misconfiguration is visible immediately instead of failing later.
+   */
+  appleOauth2ClientId?: string;
 };
 
 export type Web3NonCustodialProviderUser = {
@@ -183,9 +187,13 @@ export class Web3NonCustodialProvider {
   googleOauth2ClientId: string;
   twitterOauth2ClientId: string;
   discordOauth2ClientId: string;
-  appleOauth2ClientId: string;
 
   constructor(params: Web3NonCustodialProviderParams) {
+    if (params.appleOauth2ClientId) {
+      throw new Error(
+        "Apple Sign no longer supported in SDK.",
+      );
+    }
     this.projectId = params.projectId;
     this.appOrigin = params.appOrigin ? params.appOrigin : "https://utxos.dev";
     this.storageLocation = params.storageLocation
@@ -194,7 +202,6 @@ export class Web3NonCustodialProvider {
     this.googleOauth2ClientId = params.googleOauth2ClientId;
     this.twitterOauth2ClientId = params.twitterOauth2ClientId;
     this.discordOauth2ClientId = params.discordOauth2ClientId;
-    this.appleOauth2ClientId = params.appleOauth2ClientId;
   }
 
   private base64Encode(str: string): string {
@@ -492,6 +499,11 @@ export class Web3NonCustodialProvider {
     redirectUrl: string,
     callback: (authorizationUrl: string) => void,
   ) {
+    if ((provider as string) === "apple") {
+      throw new Error(
+        "Apple Sign In was removed. Use google, discord, twitter, or email.",
+      );
+    }
     if (provider === "google") {
       const googleState = JSON.stringify({
         redirect: redirectUrl,
@@ -548,25 +560,6 @@ export class Web3NonCustodialProvider {
       const twitterAuthorizeUrl =
         "https://x.com/i/oauth2/authorize?" + twitterSearchParams.toString();
       callback(twitterAuthorizeUrl);
-      return;
-    } else if (provider === "apple") {
-      const appleState = JSON.stringify({
-        redirect: redirectUrl,
-        provider: "apple",
-        projectId: this.projectId,
-      });
-      const appleSearchParams = new URLSearchParams({
-        client_id: this.appleOauth2ClientId,
-        response_type: "code",
-        redirect_uri: this.appOrigin + "/api/auth",
-        response_mode: "form_post",
-        scope: "name email",
-        state: this.base64Encode(appleState),
-      });
-      const appleAuthorizeUrl =
-        "https://appleid.apple.com/auth/authorize?" +
-        appleSearchParams.toString();
-      callback(appleAuthorizeUrl);
       return;
     } else if (provider === "email") {
       // Email uses OTP flow, not OAuth - this method should not be called for email

--- a/src/types/core/index.ts
+++ b/src/types/core/index.ts
@@ -24,6 +24,10 @@ export type Web3ProjectBranding = {
   twitterEnabled?: boolean;
   discordEnabled?: boolean;
   googleEnabled?: boolean;
+  /**
+   * Present on legacy API payloads. Apple Sign In is no longer offered; safe to ignore in UI.
+   * @deprecated
+   */
   appleEnabled?: boolean;
   emailEnabled?: boolean;
 };
@@ -58,7 +62,7 @@ export type Web3JWTBody = {
   username: string | null;
 };
 
-export type Web3AuthProvider = "google" | "discord" | "twitter" | "apple" | "email";
+export type Web3AuthProvider = "google" | "discord" | "twitter" | "email";
 
 /** Role a user can have within a project */
 export type Web3ProjectRole = "owner" | "admin" | "developer" | "billing";

--- a/src/wallet-user-controlled/index.ts
+++ b/src/wallet-user-controlled/index.ts
@@ -3,5 +3,4 @@ export * from "./web3-wallet";
 export type UserControlledWalletDirectTo =
   | "google"
   | "twitter"
-  | "discord"
-  | "apple";
+  | "discord";


### PR DESCRIPTION
## Summary

Removes Apple Sign In from the SDK's non-custodial OAuth surface.

## Breaking changes

This is a breaking change. SDK bumps to **0.2.4**. There are three vectors — **only the third requires actually calling sign-in**:

1. **Constructor throws on instantiation.** Any consumer currently passing a truthy `appleOauth2ClientId` to `new Web3NonCustodialProvider({...})` will throw at construction time. Apps with Apple configured will fail to boot until the field is removed.
2. **TypeScript compile errors from type-union narrowing.** `"apple"` is removed from `Web3AuthProvider` and `UserControlledWalletDirectTo`. Any code referencing `"apple"` as a value of these types fails `tsc`, even if sign-in is never called.
3. **`signInWithProvider("apple", …)` throws at runtime** if invoked.

## Changes

- `Web3NonCustodialProviderParams.appleOauth2ClientId` is now `?: string` and `@deprecated`. Passing a non-empty value throws from the constructor.
- `signInWithProvider(provider, …)` throws if `provider === "apple"` (cast-guarded so JS callers also crash cleanly).
- `"apple"` removed from `Web3AuthProvider` and `UserControlledWalletDirectTo` type unions.
- Apple removed from `examples/nextjs` and `examples/react-native` provider lists.
- `Web3ProjectBranding.appleEnabled?` retained as `@deprecated` so legacy API payloads continue to deserialize cleanly; UIs should ignore it.

## Migration

```diff
  new Web3NonCustodialProvider({
    projectId,
    googleOauth2ClientId,
    twitterOauth2ClientId,
    discordOauth2ClientId,
-   appleOauth2ClientId,
  });

- await provider.signInWithProvider("apple", redirectUrl, cb);
+ // use "google" | "discord" | "twitter" | "email" instead
```

## Test plan

- [ ] `pnpm build:sdk` succeeds
- [ ] Constructor throws when `appleOauth2ClientId` is truthy
- [ ] `signInWithProvider("apple", …)` throws at runtime
- [ ] Examples render only Google / Discord / Twitter / Email
